### PR TITLE
Change AbcCurrencyEngine types

### DIFF
--- a/indexAbcTypes.js
+++ b/indexAbcTypes.js
@@ -465,19 +465,19 @@ export type AbcReceiveAddress = AbcFreshAddress & {
 
 // currency plugin types ----------------------------------------------
 
-export interface AbcCurrencyEngineCallbacks {
-  +onBlockHeightChanged: (blockHeight: number) => void;
-  +onTransactionsChanged: (abcTransactions: Array<AbcTransaction>) => void;
-  +onBalanceChanged: (currencyCode: string, nativeBalance: string) => void;
-  +onAddressesChecked: (progressRatio: number) => void;
-  +onTxidsChanged: (txids: Array<string>) => void;
+export type AbcCurrencyEngineCallbacks = {
+  +onBlockHeightChanged: (blockHeight: number) => void,
+  +onTransactionsChanged: (abcTransactions: Array<AbcTransaction>) => void,
+  +onBalanceChanged: (currencyCode: string, nativeBalance: string) => void,
+  +onAddressesChecked: (progressRatio: number) => void,
+  +onTxidsChanged: (txids: Array<string>) => void
 }
 
-export interface AbcCurrencyEngineOptions {
-  callbacks: AbcCurrencyEngineCallbacks;
-  walletLocalFolder: any;
-  walletLocalEncryptedFolder: any;
-  optionalSettings?: any;
+export type AbcCurrencyEngineOptions = {
+  callbacks: AbcCurrencyEngineCallbacks,
+  walletLocalFolder: any,
+  walletLocalEncryptedFolder: any,
+  optionalSettings?: any
 }
 
 export interface AbcCurrencyEngine {
@@ -505,8 +505,8 @@ export interface AbcCurrencyEngine {
 export interface AbcCurrencyPlugin {
   +pluginName: string;
   +currencyInfo: AbcCurrencyInfo;
-  createPrivateKey(walletType: string): {};
-  derivePublicKey(walletInfo: AbcWalletInfo): {};
+  createPrivateKey(walletType: string): any;
+  derivePublicKey(walletInfo: AbcWalletInfo): any;
   makeEngine(
     walletInfo: AbcWalletInfo,
     options: AbcMakeEngineOptions


### PR DESCRIPTION
Make AbcCurrencyEngineCallbacks and AbcCurrencyEngineOptions types instead of interfaces
createPrivateKey and derivePublicKey to return `any`